### PR TITLE
2 add run as elevated

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ is as follows:
 
 ## Elevated Execution
 The steps program should be run as an administrator in an elevated process so that the run will 
-require a UAC prompt but this single UAC prompt will cover the entire list of steps.
+require a UAC prompt but this single UAC prompt will cover the entire list of steps. Elevated execution
+can be achieved using the `-elevated` switch.
 
 ## Some Examples
 You will find some test batch files and command text use in the .\steps\steps_test.go file. And here 
@@ -59,4 +60,12 @@ CMD,required,clear
 EXE,required,notepad.exe .\\README.md
 EXE,optional,calc.exe
 
+### Switches
+The following switches maybe be passed to the steps.exe in order to alter or enhance its execution behavior.
 
+| Switch | Effect |
+| ------ | ------ |
+| -verbose | Turn on verbose logging |
+| -elevated | Executes all steps as elevated user. |
+
+Note: using the `-elevated` switch will result in a single UAC prompt at the beginning of the execution.

--- a/cmd/steps/main.go
+++ b/cmd/steps/main.go
@@ -28,9 +28,10 @@ const (
 
 // filename used if none specified
 var (
-	currentPath   string = ""
+	currentPath string   = ""
 	stepsFileName string = ".steps"
-	verbose              = false
+	verbose bool         = false
+    elevated bool        = false
 )
 
 func main() {
@@ -39,7 +40,14 @@ func main() {
 	l := &steps.List{}
 
 	flag.BoolVar(&verbose, "verbose", false, "Verbose output for debugging.")
+    flag.BoolVar(&elevated, "elevated", false, "Run steps as elevated user.")
 	flag.Parse()
+
+    if elevated { 
+        if !util.CheckIsElevated() {
+            util.RunAsElevated()
+        }
+    }   
 
 	out("Steps %s, %s", Version, Build)
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/elusive/steps
 
 go 1.19
 
-require golang.org/x/sys v0.11.0 // indirect
+require golang.org/x/sys v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/util/runas.go
+++ b/util/runas.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+    "fmt"
+    "os"
+    "strings"
+    "syscall"
+
+    "golang.org/x/sys/windows"
+)
+
+func RunAsElevated() {
+	verb := "runas"
+	exe, _ := os.Executable()
+	cwd, _ := os.Getwd()
+	args := strings.Join(os.Args[1:], " ")
+	
+	verbPtr, _ := syscall.UTF16PtrFromString(verb)
+	exePtr, _ := syscall.UTF16PtrFromString(exe)
+	cwdPtr, _ := syscall.UTF16PtrFromString(cwd)
+	argPtr, _ := syscall.UTF16PtrFromString(args)
+	
+	var showCmd int32 = 1 //SW_NORMAL
+	
+	err := windows.ShellExecute(0, verbPtr, exePtr, argPtr, cwdPtr, showCmd)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func CheckIsElevated() bool {
+	_, err := os.Open("\\\\.\\PHYSICALDRIVE0")
+	if err != nil {
+		fmt.Println("Not elevated.")
+		return false
+	}
+	fmt.Println("Running Elevated!")
+	return true
+}


### PR DESCRIPTION
Add the `-elevated` switch and its behavior. Support for run as elevated in the util package added. Used in main at beginning of execution to check if elevated and run as elevated if indicated by switch.